### PR TITLE
chore: v0.1.0 release notes [no ci]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,1 +1,5 @@
 # Release History - `Autonomous Fund`
+
+## 0.1.0 (2022-11-18)
+
+- The first release of the Autonomous Fund, configured to run on Goerli with 4 agents. It utilizes the Fear and Greed Index to adjust the weights of a pool containing BTC, ETH and USDC.


### PR DESCRIPTION
This PR adds the release notes for the first version (v0.1.0) of the Autonomous Fund. 