### PR TITLE
chore: add supported versions in security [no ci]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ The following table shows which versions of `autonomous-fund` are currently bein
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `N/A`     | :x:                |
+| `v0.1.0`  | ✔️                  |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This PR adds `v0.1.0` to the list of supported versions.