### PR TITLE
chore: bump to open-autonomy@v0.4.0.post1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,12 +21,12 @@ pytest = "==7.0.0"
 pytest-asyncio = "==0.18.0"
 pytest-cov = "==3.0.0"
 pytest-randomly = "==3.11.0"
-open-aea = "==1.24.0"
+open-aea = "==1.24.0.post1"
 open-aea-ledger-ethereum = "==1.24.0"
 open-aea-ledger-cosmos = "==1.24.0"
 open-aea-cli-ipfs = "==1.24.0"
 open-aea-test-autonomy = "==0.4.0"
-open-autonomy = {version = "==0.4.0", extras = [ "all"]}
+open-autonomy = {version = "==0.4.0.post1", extras = [ "all"]}
 tomte = {version = "==0.1.5", extras = ["tox", "tests"]}
 
 [requires]

--- a/packages/balancer/agents/autonomous_fund/aea-config.yaml
+++ b/packages/balancer/agents/autonomous_fund/aea-config.yaml
@@ -32,15 +32,15 @@ contracts:
 protocols:
 - open_aea/signing:1.0.0:bafybeiambqptflge33eemdhis2whik67hjplfnqwieoa6wblzlaf7vuo44
 skills:
-- balancer/autonomous_fund_abci:0.1.0:bafybeieoolxcjygmycaxvngdb64m4nn2tf3s7mxmkqazywwqnjptc42a3m
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeicdmq5557o4epoizzkduem4xz57rkhaptswi2aqisdn5x7xcpkpfi
-- balancer/pool_manager_abci:0.1.0:bafybeicoxskrkd5uhshc3nm6bjumelwrvxskmldnmjqm3klk5gr7xa3wky
+- balancer/autonomous_fund_abci:0.1.0:bafybeicfaelqxlcpda2bf2kyc62egynaxtwl5nyhi2oli2rbxaqn5uc27i
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeihepj6zaidkylh6vczxb7vv2hzd4ghtitizgjia4iqmtgtlbutsfi
+- balancer/pool_manager_abci:0.1.0:bafybeigflumois3mhxgavdlcwuc4typsrl3owtsxgwha2bdr6ejeebcqlq
 - valory/abstract_abci:0.1.0:bafybeicog4eierjad4f542ubhe3ez7sxgrsna7t2e5pci2hncpq5vckw4e
-- valory/abstract_round_abci:0.1.0:bafybeid3sx66tzs6mmwu52tlaqdycfszzpetgybzu34gagfocg5bmivh7e
-- valory/registration_abci:0.1.0:bafybeifxquhkccygjawoqyj26b3k6rxizaa7geoef7oyet2baojjk4gy2q
-- valory/reset_pause_abci:0.1.0:bafybeibnziujsv7toespbguradspw52rfrhhgdojcbznckqia2jwm2jvwm
-- valory/safe_deployment_abci:0.1.0:bafybeig4bni62vg6bschvvtnpsg5p6p7owqispx64zomk4pqcugmqv4wpe
-- valory/transaction_settlement_abci:0.1.0:bafybeiaaugllwdbh5pmnus2gbnsr72cvdysoobb7gf2ccmtctvxzdqcpii
+- valory/abstract_round_abci:0.1.0:bafybeia5meor4p77p62khoddlqj4vg5rxiwi3djxc7feusgein6adi7t7m
+- valory/registration_abci:0.1.0:bafybeib2cr65zmunztkr3miy4sa2pwlsj2dsi4pz7rwtgg75xczc7hrj3q
+- valory/reset_pause_abci:0.1.0:bafybeie3qy5v3ggc54bmrubd27kbofrkw6srgbggo3b6ewssw3pbxjuvla
+- valory/safe_deployment_abci:0.1.0:bafybeih2mywgkx2z6fdjdumr3ghdth54gp6glyltrasezyo37bu3zqk7by
+- valory/transaction_settlement_abci:0.1.0:bafybeicjc5fa4lheqiymguk2auvcg7wzvigwzgay3mcryy2puwvxapptku
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/balancer/services/autonomous_fund/service.yaml
+++ b/packages/balancer/services/autonomous_fund/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeicdyhjhou5zymkztgxubvtzwwrldmzbhophrmtkubnuoh7pbwpcsq
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeieuzi3iz6lpapqfjticmqguqa2dqxijaec237zx5vyxyfsqhidvgm
+agent: balancer/autonomous_fund:0.1.0:bafybeibcdpdfjozgnwc2dd2mcfd34taihglmojg3y2mei5n5tn7yf52bne
 number_of_agents: 4
 ---
 public_id: balancer/autonomous_fund_abci:0.1.0

--- a/packages/balancer/skills/autonomous_fund_abci/skill.yaml
+++ b/packages/balancer/skills/autonomous_fund_abci/skill.yaml
@@ -23,13 +23,13 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeicdmq5557o4epoizzkduem4xz57rkhaptswi2aqisdn5x7xcpkpfi
-- balancer/pool_manager_abci:0.1.0:bafybeicoxskrkd5uhshc3nm6bjumelwrvxskmldnmjqm3klk5gr7xa3wky
-- valory/abstract_round_abci:0.1.0:bafybeid3sx66tzs6mmwu52tlaqdycfszzpetgybzu34gagfocg5bmivh7e
-- valory/registration_abci:0.1.0:bafybeifxquhkccygjawoqyj26b3k6rxizaa7geoef7oyet2baojjk4gy2q
-- valory/reset_pause_abci:0.1.0:bafybeibnziujsv7toespbguradspw52rfrhhgdojcbznckqia2jwm2jvwm
-- valory/safe_deployment_abci:0.1.0:bafybeig4bni62vg6bschvvtnpsg5p6p7owqispx64zomk4pqcugmqv4wpe
-- valory/transaction_settlement_abci:0.1.0:bafybeiaaugllwdbh5pmnus2gbnsr72cvdysoobb7gf2ccmtctvxzdqcpii
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeihepj6zaidkylh6vczxb7vv2hzd4ghtitizgjia4iqmtgtlbutsfi
+- balancer/pool_manager_abci:0.1.0:bafybeigflumois3mhxgavdlcwuc4typsrl3owtsxgwha2bdr6ejeebcqlq
+- valory/abstract_round_abci:0.1.0:bafybeia5meor4p77p62khoddlqj4vg5rxiwi3djxc7feusgein6adi7t7m
+- valory/registration_abci:0.1.0:bafybeib2cr65zmunztkr3miy4sa2pwlsj2dsi4pz7rwtgg75xczc7hrj3q
+- valory/reset_pause_abci:0.1.0:bafybeie3qy5v3ggc54bmrubd27kbofrkw6srgbggo3b6ewssw3pbxjuvla
+- valory/safe_deployment_abci:0.1.0:bafybeih2mywgkx2z6fdjdumr3ghdth54gp6glyltrasezyo37bu3zqk7by
+- valory/transaction_settlement_abci:0.1.0:bafybeicjc5fa4lheqiymguk2auvcg7wzvigwzgay3mcryy2puwvxapptku
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
+++ b/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeid3sx66tzs6mmwu52tlaqdycfszzpetgybzu34gagfocg5bmivh7e
+- valory/abstract_round_abci:0.1.0:bafybeia5meor4p77p62khoddlqj4vg5rxiwi3djxc7feusgein6adi7t7m
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/pool_manager_abci/skill.yaml
+++ b/packages/balancer/skills/pool_manager_abci/skill.yaml
@@ -30,8 +30,8 @@ contracts:
 protocols:
 - valory/contract_api:1.0.0:bafybeiaxbrvgtbdrh4lslskuxyp4awyr4whcx3nqq5yrr6vimzsxg5dy64
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeid3sx66tzs6mmwu52tlaqdycfszzpetgybzu34gagfocg5bmivh7e
-- valory/transaction_settlement_abci:0.1.0:bafybeiaaugllwdbh5pmnus2gbnsr72cvdysoobb7gf2ccmtctvxzdqcpii
+- valory/abstract_round_abci:0.1.0:bafybeia5meor4p77p62khoddlqj4vg5rxiwi3djxc7feusgein6adi7t7m
+- valory/transaction_settlement_abci:0.1.0:bafybeicjc5fa4lheqiymguk2auvcg7wzvigwzgay3mcryy2puwvxapptku
 behaviours:
   main:
     args: {}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,12 +1,12 @@
 {
     "dev": {
-        "agent/balancer/autonomous_fund/0.1.0": "bafybeieuzi3iz6lpapqfjticmqguqa2dqxijaec237zx5vyxyfsqhidvgm",
-        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeieoolxcjygmycaxvngdb64m4nn2tf3s7mxmkqazywwqnjptc42a3m",
-        "skill/balancer/pool_manager_abci/0.1.0": "bafybeicoxskrkd5uhshc3nm6bjumelwrvxskmldnmjqm3klk5gr7xa3wky",
-        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeicdmq5557o4epoizzkduem4xz57rkhaptswi2aqisdn5x7xcpkpfi",
+        "agent/balancer/autonomous_fund/0.1.0": "bafybeibcdpdfjozgnwc2dd2mcfd34taihglmojg3y2mei5n5tn7yf52bne",
+        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeicfaelqxlcpda2bf2kyc62egynaxtwl5nyhi2oli2rbxaqn5uc27i",
+        "skill/balancer/pool_manager_abci/0.1.0": "bafybeigflumois3mhxgavdlcwuc4typsrl3owtsxgwha2bdr6ejeebcqlq",
+        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeihepj6zaidkylh6vczxb7vv2hzd4ghtitizgjia4iqmtgtlbutsfi",
         "contract/balancer/managed_pool_controller/0.1.0": "bafybeiehd6hc5zpigr3tl2j4x4wzj35qjm27mcnv5uqdexoib7g4gn2mxi",
         "contract/balancer/managed_pool/0.1.0": "bafybeibdvfjbkz5rdhhnoc6w75vgnaeo6ahh4w36c5e44lqcihc2omy3zq",
-        "service/balancer/autonomous_fund/0.1.0": "bafybeigdyoaa3fdsobowttt23c4z26s34niub3wr5cicvqsbjv4zxqm2ve"
+        "service/balancer/autonomous_fund/0.1.0": "bafybeicieyyujuqnkf3lymjnqfseamvfimiwzlzn5u7c6cqkzzfrcorgvm"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiaw3tzlg3rkvnn5fcufblktmfwngmxugn4yo7pyjp76zz6aqtqcay",
@@ -23,11 +23,11 @@
         "skill/valory/abstract_abci/0.1.0": "bafybeicog4eierjad4f542ubhe3ez7sxgrsna7t2e5pci2hncpq5vckw4e",
         "contract/valory/gnosis_safe/0.1.0": "bafybeidoa7hkpzpnjswns2jq6tlisbzinzpkdqtqd6gbpyxiytt3mnszpm",
         "protocol/valory/acn/1.1.0": "bafybeifontek6tvaecatoauiule3j3id6xoktpjubvuqi3h2jkzqg7zh7a",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeid3sx66tzs6mmwu52tlaqdycfszzpetgybzu34gagfocg5bmivh7e",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeia5meor4p77p62khoddlqj4vg5rxiwi3djxc7feusgein6adi7t7m",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeidkk33xbga54szmitk6uwsi3ef56hbbdbuasltqtiyki34hgfpnxa",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeiaaugllwdbh5pmnus2gbnsr72cvdysoobb7gf2ccmtctvxzdqcpii",
-        "skill/valory/registration_abci/0.1.0": "bafybeifxquhkccygjawoqyj26b3k6rxizaa7geoef7oyet2baojjk4gy2q",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeibnziujsv7toespbguradspw52rfrhhgdojcbznckqia2jwm2jvwm",
-        "skill/valory/safe_deployment_abci/0.1.0": "bafybeig4bni62vg6bschvvtnpsg5p6p7owqispx64zomk4pqcugmqv4wpe"
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeicjc5fa4lheqiymguk2auvcg7wzvigwzgay3mcryy2puwvxapptku",
+        "skill/valory/registration_abci/0.1.0": "bafybeib2cr65zmunztkr3miy4sa2pwlsj2dsi4pz7rwtgg75xczc7hrj3q",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeie3qy5v3ggc54bmrubd27kbofrkw6srgbggo3b6ewssw3pbxjuvla",
+        "skill/valory/safe_deployment_abci/0.1.0": "bafybeih2mywgkx2z6fdjdumr3ghdth54gp6glyltrasezyo37bu3zqk7by"
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,12 @@ deps =
     pytest-randomly==3.11.0
     pytest-cov==3.0.0
     pytest-asyncio==0.18.0
-    open-aea==1.24.0
+    open-aea==1.24.0.post1
     open-aea-ledger-ethereum==1.24.0
     open-aea-ledger-cosmos==1.24.0
     open-aea-cli-ipfs==1.24.0
     open-aea-test-autonomy==0.4.0
-    open-autonomy==0.4.0
+    open-autonomy==0.4.0.post1
 setenv =
     PYTHONHASHSEED=0
 commands =


### PR DESCRIPTION
This PR bumps the autonomous fund to `open-autonomy@v0.4.0.post1`.