### PR TITLE
fix: add env vars to `aea-config.yaml`

### DIFF
--- a/packages/balancer/agents/autonomous_fund/aea-config.yaml
+++ b/packages/balancer/agents/autonomous_fund/aea-config.yaml
@@ -140,7 +140,7 @@ models:
       history_check_timeout: 1205
       keeper_allowed_retries: 3
       keeper_timeout: 30.0
-      managed_pool_controller_address: '0xb821BFfE924E18F8B3d92473C5279d60F0Dfc6eA'
+      managed_pool_controller_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_CONTROLLER_ADDRESS:str:0xb821BFfE924E18F8B3d92473C5279d60F0Dfc6eA}
       max_healthcheck: 120
       max_index_change: 0.00040509259
       max_index_value: 100
@@ -168,8 +168,7 @@ models:
       service_id: pool_manager
       service_registry_address: null
       setup:
-        safe_contract_address:
-        - '0x8001bdCf80F8Fb61CdcDA48419A30b430B385ca1'
+        safe_contract_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_SETUP_SAFE_CONTRACT_ADDRESS:list:["0x8001bdCf80F8Fb61CdcDA48419A30b430B385ca1"]}
       sleep_time: 1
       tendermint_check_sleep_delay: 3
       tendermint_com_url: http://localhost:8080
@@ -178,4 +177,4 @@ models:
       validate_timeout: 1205
       weight_tolerance: 0.1
       weight_update_timespan: 72000
-      managed_pool_address: '0x28BF8d29cFA99aE9C3D876210453272f30e4D131'
+      managed_pool_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_ADDRESS:str:0x28BF8d29cFA99aE9C3D876210453272f30e4D131}

--- a/packages/balancer/services/autonomous_fund/service.yaml
+++ b/packages/balancer/services/autonomous_fund/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeicdyhjhou5zymkztgxubvtzwwrldmzbhophrmtkubnuoh7pbwpcsq
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeibcdpdfjozgnwc2dd2mcfd34taihglmojg3y2mei5n5tn7yf52bne
+agent: balancer/autonomous_fund:0.1.0:bafybeigw2ghyywgygfbcymtr4vm6didxhq2ariwhq3inxi3gzqvx5ts2qm
 number_of_agents: 4
 ---
 public_id: balancer/autonomous_fund_abci:0.1.0
@@ -16,9 +16,9 @@ models:
   params:
     args:
       setup:
-        safe_contract_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_SETUP_SAFE_CONTRACT_ADDRESS:list:[]}
-      managed_pool_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_ADDRESS:str:0x28BF8d29cFA99aE9C3D876210453272f30e4D131}
-      managed_pool_controller_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_CONTROLLER_ADDRESS:str:0xb821BFfE924E18F8B3d92473C5279d60F0Dfc6eA}
+        safe_contract_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_SETUP_SAFE_CONTRACT_ADDRESS:list:["0xD1A2679e3455a018d9e0D11edb873e7C5B5d831e"]}
+      managed_pool_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_ADDRESS:str:0xE7718Db6786516f426cC72673088e628Ac4721A1}
+      managed_pool_controller_address: ${SKILL_AUTONOMOUS_FUND_ABCI_MODELS_PARAMS_ARGS_MANAGED_POOL_CONTROLLER_ADDRESS:str:0x7017752b993958d7b4e65bf68a08c7833840f1e8}
       consensus:
         max_participants: 4
       observation_interval: 300

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,12 +1,12 @@
 {
     "dev": {
-        "agent/balancer/autonomous_fund/0.1.0": "bafybeibcdpdfjozgnwc2dd2mcfd34taihglmojg3y2mei5n5tn7yf52bne",
+        "agent/balancer/autonomous_fund/0.1.0": "bafybeigw2ghyywgygfbcymtr4vm6didxhq2ariwhq3inxi3gzqvx5ts2qm",
         "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeicfaelqxlcpda2bf2kyc62egynaxtwl5nyhi2oli2rbxaqn5uc27i",
         "skill/balancer/pool_manager_abci/0.1.0": "bafybeigflumois3mhxgavdlcwuc4typsrl3owtsxgwha2bdr6ejeebcqlq",
         "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeihepj6zaidkylh6vczxb7vv2hzd4ghtitizgjia4iqmtgtlbutsfi",
         "contract/balancer/managed_pool_controller/0.1.0": "bafybeiehd6hc5zpigr3tl2j4x4wzj35qjm27mcnv5uqdexoib7g4gn2mxi",
         "contract/balancer/managed_pool/0.1.0": "bafybeibdvfjbkz5rdhhnoc6w75vgnaeo6ahh4w36c5e44lqcihc2omy3zq",
-        "service/balancer/autonomous_fund/0.1.0": "bafybeicieyyujuqnkf3lymjnqfseamvfimiwzlzn5u7c6cqkzzfrcorgvm"
+        "service/balancer/autonomous_fund/0.1.0": "bafybeicfkzh5ok5xpdu7xisybxdfw25qh2v65xd3hvgvycydjknv2ph4qy"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiaw3tzlg3rkvnn5fcufblktmfwngmxugn4yo7pyjp76zz6aqtqcay",


### PR DESCRIPTION
This PR adds env vars to the aea-config.yaml to enable service overrides.