### PR TITLE
Bumps open-aea and open-autonomy to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,12 +22,12 @@ pytest-asyncio = "==0.20.3"
 pytest-cov = "==4.0.0"
 pytest-randomly = "==3.12.0"
 requests = "==2.28.1"
-open-aea = "==1.48.0"
-open-aea-ledger-ethereum = "==1.48.0"
-open-aea-ledger-cosmos = "==1.48.0"
-open-aea-cli-ipfs = "==1.48.0"
-open-aea-test-autonomy = "==0.14.6"
-open-autonomy = {version = "==0.14.6", extras = ["all"]}
+open-aea = "==1.48.0.post1"
+open-aea-ledger-ethereum = "==1.48.0.post1"
+open-aea-ledger-cosmos = "==1.48.0.post1"
+open-aea-cli-ipfs = "==1.48.0.post1"
+open-aea-test-autonomy = "==0.14.7"
+open-autonomy = {version = "==0.14.7", extras = ["all"]}
 tomte = {version = "==0.2.15", extras = ["cli", "tests"]}
 openapi-core = "==0.15.0"
 openapi-spec-validator = "<0.5.0,>=0.4.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ In order to run a local demo based on the SMPKit:
 2. Fetch the Smart Managed Pools service.
 
     ```bash
-    autonomy fetch balancer/autonomous_fund_goerli:0.1.0:bafybeicauzskauyp2st557z4atidp7ctaant3wsc2kfsih3mmdllbedv74 --service
+    autonomy fetch balancer/autonomous_fund_goerli:0.1.0:bafybeiawoqxmd2cuehlrialiyn4oq4sv2zt6jtjbkpoocdy523jbfvpmvq --service
     ```
 
 3. Build the Docker image of the service agents

--- a/packages/balancer/agents/autonomous_fund/aea-config.yaml
+++ b/packages/balancer/agents/autonomous_fund/aea-config.yaml
@@ -21,27 +21,27 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq
+- valory/abci:0.1.0:bafybeichtqrs5wafa23zli4365ph74ve345c7qf4hyhwkywvln4ccn2jrm
 - valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
-- valory/ipfs:0.1.0:bafybeiflaxrnepfn4hcnq5pieuc7ki7d422y3iqb54lv4tpgs7oywnuhhq
+- valory/ipfs:0.1.0:bafybeic7zx3tprybs7whs2odzsvqff2ohwaymo7calhki3nsdbokubhqte
 - valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
+- balancer/managed_pool:0.1.0:bafybeick3wyjoxcuq5ih6e2mp5fv6wmoee4llor5ppkz6fvtojxhz5pfhi
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- balancer/autonomous_fund_abci:0.1.0:bafybeidxvsswhu6rqr6ijoaehtqjmdbubmt7lloe6ecbehho46dwnx76nu
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq
-- balancer/liquidity_provision_abci:0.1.0:bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu
-- balancer/pool_manager_abci:0.1.0:bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm
-- valory/abstract_abci:0.1.0:bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- balancer/autonomous_fund_abci:0.1.0:bafybeihz43ync4yaypposf3ycmyvnsw7czqod3nsxt3dzc57pfoqpeoi4q
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeibhizvihh7v54dk6xilqv2lqbllg6jpyslrd22iepenjbla4zvfmq
+- balancer/liquidity_provision_abci:0.1.0:bafybeicqg5hrv5ikpfxcb2gmrtdeyvqvxypebmpqlnofwqq3xxfpy2vpce
+- balancer/pool_manager_abci:0.1.0:bafybeicbdgg5pptne57ndurxh4znec5c5hstypzy3tlyleyy76bh2tm3be
+- valory/abstract_abci:0.1.0:bafybeiap7xqpci6pjlpd2yrmkguuohvsbycz725jpvz3xbgt6e2or5iucu
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/registration_abci:0.1.0:bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue
+- valory/reset_pause_abci:0.1.0:bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li
+- valory/termination_abci:0.1.0:bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -73,9 +73,9 @@ logging_config:
 skill_exception_policy: stop_and_exit
 dependencies:
   open-aea-ledger-cosmos:
-    version: ==1.48.0
+    version: ==1.48.0.post1
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.48.0.post1
 default_connection: null
 ---
 public_id: valory/abci:0.1.0

--- a/packages/balancer/contracts/managed_pool/contract.yaml
+++ b/packages/balancer/contracts/managed_pool/contract.yaml
@@ -16,6 +16,6 @@ contract_interface_paths:
   ethereum: build/IManagedPool.json
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.48.0.post1
   web3:
     version: <7,>=6.0.0

--- a/packages/balancer/services/autonomous_fund/service.yaml
+++ b/packages/balancer/services/autonomous_fund/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibfahh3htjez7vf7lwx2s7tth26cwxgtalgn5hj7yg7akhk67f4ny
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeif4hhzy3sfmzgpq5qip5mdgyr3ok42huosfwtdltsay4fbyvqyd54
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/services/autonomous_fund_gnosis/service.yaml
+++ b/packages/balancer/services/autonomous_fund_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeieehvmcyig6zmiwoueqihxgnwvwfsqhadxbgwk7olus3jfdw4cn3q
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeif4hhzy3sfmzgpq5qip5mdgyr3ok42huosfwtdltsay4fbyvqyd54
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/services/autonomous_fund_goerli/service.yaml
+++ b/packages/balancer/services/autonomous_fund_goerli/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeie36flrik7sho37ynqzv7vc4thd5daw7h3af6fvi4o467fddbwgte
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeif4hhzy3sfmzgpq5qip5mdgyr3ok42huosfwtdltsay4fbyvqyd54
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/skills/autonomous_fund_abci/skill.yaml
+++ b/packages/balancer/skills/autonomous_fund_abci/skill.yaml
@@ -27,14 +27,14 @@ contracts: []
 protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq
-- balancer/liquidity_provision_abci:0.1.0:bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu
-- balancer/pool_manager_abci:0.1.0:bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeibhizvihh7v54dk6xilqv2lqbllg6jpyslrd22iepenjbla4zvfmq
+- balancer/liquidity_provision_abci:0.1.0:bafybeicqg5hrv5ikpfxcb2gmrtdeyvqvxypebmpqlnofwqq3xxfpy2vpce
+- balancer/pool_manager_abci:0.1.0:bafybeicbdgg5pptne57ndurxh4znec5c5hstypzy3tlyleyy76bh2tm3be
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/registration_abci:0.1.0:bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue
+- valory/reset_pause_abci:0.1.0:bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li
+- valory/termination_abci:0.1.0:bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 behaviours:
   main:
     args: {}
@@ -204,5 +204,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-cli-ipfs:
-    version: ==1.48.0
+    version: ==1.48.0.post1
 is_abstract: false

--- a/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
+++ b/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/liquidity_provision_abci/skill.yaml
+++ b/packages/balancer/skills/liquidity_provision_abci/skill.yaml
@@ -24,14 +24,14 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
+- balancer/managed_pool:0.1.0:bafybeick3wyjoxcuq5ih6e2mp5fv6wmoee4llor5ppkz6fvtojxhz5pfhi
+- valory/gnosis_safe:0.1.0:bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/pool_manager_abci/skill.yaml
+++ b/packages/balancer/skills/pool_manager_abci/skill.yaml
@@ -24,13 +24,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
+- balancer/managed_pool:0.1.0:bafybeick3wyjoxcuq5ih6e2mp5fv6wmoee4llor5ppkz6fvtojxhz5pfhi
+- valory/gnosis_safe:0.1.0:bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 behaviours:
   main:
     args: {}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,14 +1,14 @@
 {
     "dev": {
-        "contract/balancer/managed_pool/0.1.0": "bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m",
-        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeidxvsswhu6rqr6ijoaehtqjmdbubmt7lloe6ecbehho46dwnx76nu",
-        "skill/balancer/pool_manager_abci/0.1.0": "bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm",
-        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq",
-        "skill/balancer/liquidity_provision_abci/0.1.0": "bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu",
-        "agent/balancer/autonomous_fund/0.1.0": "bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a",
-        "service/balancer/autonomous_fund_gnosis/0.1.0": "bafybeigvb4c65r2imymulqnrif2niv7xlldxv72dyru62lgwcbzyf2vzvu",
-        "service/balancer/autonomous_fund_goerli/0.1.0": "bafybeicauzskauyp2st557z4atidp7ctaant3wsc2kfsih3mmdllbedv74",
-        "service/balancer/autonomous_fund/0.1.0": "bafybeieina6fyq7762otrkriebwlhtmufkxkd42uzs7reqxgfl6o2pejgy"
+        "contract/balancer/managed_pool/0.1.0": "bafybeick3wyjoxcuq5ih6e2mp5fv6wmoee4llor5ppkz6fvtojxhz5pfhi",
+        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeihz43ync4yaypposf3ycmyvnsw7czqod3nsxt3dzc57pfoqpeoi4q",
+        "skill/balancer/pool_manager_abci/0.1.0": "bafybeicbdgg5pptne57ndurxh4znec5c5hstypzy3tlyleyy76bh2tm3be",
+        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeibhizvihh7v54dk6xilqv2lqbllg6jpyslrd22iepenjbla4zvfmq",
+        "skill/balancer/liquidity_provision_abci/0.1.0": "bafybeicqg5hrv5ikpfxcb2gmrtdeyvqvxypebmpqlnofwqq3xxfpy2vpce",
+        "agent/balancer/autonomous_fund/0.1.0": "bafybeif4hhzy3sfmzgpq5qip5mdgyr3ok42huosfwtdltsay4fbyvqyd54",
+        "service/balancer/autonomous_fund_gnosis/0.1.0": "bafybeiedue53u4o5oxws4npxu6eslcwdhejaeux6yomnmphvcybztiyv3e",
+        "service/balancer/autonomous_fund_goerli/0.1.0": "bafybeiawoqxmd2cuehlrialiyn4oq4sv2zt6jtjbkpoocdy523jbfvpmvq",
+        "service/balancer/autonomous_fund/0.1.0": "bafybeiepiveeob7otklamvg3cuikg5n3tpkwfcrplspdwphr32pg2djbxi"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u",
@@ -19,21 +19,21 @@
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeie6ynnoavvk2fpbn426nlp32sxrj7pz5esgebtlezy4tmx5gjretm",
-        "contract/valory/service_registry/0.1.0": "bafybeiby5x4wfdywlenmoudbykdxohpq2nifqxfep5niqgxrjyrekyahzy",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeiegrcfqdqrp23p4u727ic7uybtdvseibzzm3rvyshfdfpqrffut5m",
+        "contract/valory/service_registry/0.1.0": "bafybeichwywpb7nwxdx7ytqke55fij3fth36ozkceo7kth4szx4ie4pouy",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "connection/valory/abci/0.1.0": "bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq",
+        "connection/valory/abci/0.1.0": "bafybeichtqrs5wafa23zli4365ph74ve345c7qf4hyhwkywvln4ccn2jrm",
         "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
         "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "connection/valory/ipfs/0.1.0": "bafybeiflaxrnepfn4hcnq5pieuc7ki7d422y3iqb54lv4tpgs7oywnuhhq",
+        "connection/valory/ipfs/0.1.0": "bafybeic7zx3tprybs7whs2odzsvqff2ohwaymo7calhki3nsdbokubhqte",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe",
-        "skill/valory/registration_abci/0.1.0": "bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea",
-        "skill/valory/termination_abci/0.1.0": "bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay"
+        "skill/valory/abstract_abci/0.1.0": "bafybeiap7xqpci6pjlpd2yrmkguuohvsbycz725jpvz3xbgt6e2or5iucu",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4",
+        "skill/valory/registration_abci/0.1.0": "bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li",
+        "skill/valory/termination_abci/0.1.0": "bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze"
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,12 @@ deps =
     pytest-cov==4.0.0
     pytest-asyncio==0.20.3
     requests==2.28.1
-    open-aea==1.48.0
-    open-aea-ledger-ethereum==1.48.0
-    open-aea-ledger-cosmos==1.48.0
-    open-aea-cli-ipfs==1.48.0
-    open-aea-test-autonomy==0.14.6
-    open-autonomy==0.14.6
+    open-aea==1.48.0.post1
+    open-aea-ledger-ethereum==1.48.0.post1
+    open-aea-ledger-cosmos==1.48.0.post1
+    open-aea-cli-ipfs==1.48.0.post1
+    open-aea-test-autonomy==0.14.7
+    open-autonomy==0.14.7
     openapi-core==0.15.0
     openapi-spec-validator<0.5.0,>=0.4.0
     protobuf<4.25.0,>=4.21.6


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum-flashbots to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum-hwi to ==1.48.0.post1
- Bumps open-aea-ledger-cosmos to ==1.48.0.post1
- Bumps open-aea-ledger-solana to ==1.48.0.post1
- Bumps open-aea-cli-ipfs to ==1.48.0.post1
- Bumps open-autonomy to ==0.14.7
- Bumps open-aea-test-autonomy to ==0.14.7