### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,12 +22,12 @@ pytest-asyncio = "==0.20.3"
 pytest-cov = "==4.0.0"
 pytest-randomly = "==3.12.0"
 requests = "==2.28.1"
-open-aea = "==1.48.0"
-open-aea-ledger-ethereum = "==1.48.0"
-open-aea-ledger-cosmos = "==1.48.0"
-open-aea-cli-ipfs = "==1.48.0"
-open-aea-test-autonomy = "==0.14.6"
-open-autonomy = {version = "==0.14.6", extras = ["all"]}
+open-aea = "==1.50.0"
+open-aea-ledger-ethereum = "==1.50.0"
+open-aea-ledger-cosmos = "==1.50.0"
+open-aea-cli-ipfs = "==1.50.0"
+open-aea-test-autonomy = "==0.14.9"
+open-autonomy = {version = "==0.14.9", extras = ["all"]}
 tomte = {version = "==0.2.15", extras = ["cli", "tests"]}
 openapi-core = "==0.15.0"
 openapi-spec-validator = "<0.5.0,>=0.4.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ In order to run a local demo based on the SMPKit:
 2. Fetch the Smart Managed Pools service.
 
     ```bash
-    autonomy fetch balancer/autonomous_fund_goerli:0.1.0:bafybeicauzskauyp2st557z4atidp7ctaant3wsc2kfsih3mmdllbedv74 --service
+    autonomy fetch balancer/autonomous_fund_goerli:0.1.0:bafybeibuozg5xa6wzrd5sizon3vaddqyfhalouoezf4z7m3izrjid3wb4y --service
     ```
 
 3. Build the Docker image of the service agents

--- a/packages/balancer/agents/autonomous_fund/aea-config.yaml
+++ b/packages/balancer/agents/autonomous_fund/aea-config.yaml
@@ -21,27 +21,27 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq
+- valory/abci:0.1.0:bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra
 - valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
-- valory/ipfs:0.1.0:bafybeiflaxrnepfn4hcnq5pieuc7ki7d422y3iqb54lv4tpgs7oywnuhhq
+- valory/ipfs:0.1.0:bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii
 - valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
+- balancer/managed_pool:0.1.0:bafybeifpwwu3frha2k2mticchc4qxnaceaswuamqfq2ejb6m5e6iwcuo3q
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- balancer/autonomous_fund_abci:0.1.0:bafybeidxvsswhu6rqr6ijoaehtqjmdbubmt7lloe6ecbehho46dwnx76nu
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq
-- balancer/liquidity_provision_abci:0.1.0:bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu
-- balancer/pool_manager_abci:0.1.0:bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm
-- valory/abstract_abci:0.1.0:bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- balancer/autonomous_fund_abci:0.1.0:bafybeiahetwxxfo2h55hskgvccz624i6w5wq6vs5ber4osngzorfpxxtea
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeicdvt7cbezzptcwpmjfz4pg2nkfa6oez2l6ptqufarsxirrvlonqm
+- balancer/liquidity_provision_abci:0.1.0:bafybeigchesydp5dusscvelsyzrhhd7f72lrfg7iwlqmop6ljnizehfplm
+- balancer/pool_manager_abci:0.1.0:bafybeicrialf4wk4iopqcnm3emdd4yfhw4bmby2jadzlpuo2cytkhwyhyu
+- valory/abstract_abci:0.1.0:bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre
+- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/registration_abci:0.1.0:bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a
+- valory/reset_pause_abci:0.1.0:bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu
+- valory/termination_abci:0.1.0:bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe
+- valory/transaction_settlement_abci:0.1.0:bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -73,9 +73,9 @@ logging_config:
 skill_exception_policy: stop_and_exit
 dependencies:
   open-aea-ledger-cosmos:
-    version: ==1.48.0
+    version: ==1.50.0
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.50.0
 default_connection: null
 ---
 public_id: valory/abci:0.1.0

--- a/packages/balancer/contracts/managed_pool/contract.yaml
+++ b/packages/balancer/contracts/managed_pool/contract.yaml
@@ -16,6 +16,6 @@ contract_interface_paths:
   ethereum: build/IManagedPool.json
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.50.0
   web3:
     version: <7,>=6.0.0

--- a/packages/balancer/services/autonomous_fund/service.yaml
+++ b/packages/balancer/services/autonomous_fund/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeibfahh3htjez7vf7lwx2s7tth26cwxgtalgn5hj7yg7akhk67f4ny
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeifod3vme4xrwoniptkuks2hazpta6iuluynkgwwvvoal2hqj32sp4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/services/autonomous_fund_gnosis/service.yaml
+++ b/packages/balancer/services/autonomous_fund_gnosis/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeieehvmcyig6zmiwoueqihxgnwvwfsqhadxbgwk7olus3jfdw4cn3q
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeifod3vme4xrwoniptkuks2hazpta6iuluynkgwwvvoal2hqj32sp4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/services/autonomous_fund_goerli/service.yaml
+++ b/packages/balancer/services/autonomous_fund_goerli/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeie36flrik7sho37ynqzv7vc4thd5daw7h3af6fvi4o467fddbwgte
 fingerprint_ignore_patterns: []
-agent: balancer/autonomous_fund:0.1.0:bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a
+agent: balancer/autonomous_fund:0.1.0:bafybeifod3vme4xrwoniptkuks2hazpta6iuluynkgwwvvoal2hqj32sp4
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/balancer/skills/autonomous_fund_abci/skill.yaml
+++ b/packages/balancer/skills/autonomous_fund_abci/skill.yaml
@@ -27,14 +27,14 @@ contracts: []
 protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq
-- balancer/liquidity_provision_abci:0.1.0:bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu
-- balancer/pool_manager_abci:0.1.0:bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- balancer/fear_and_greed_oracle_abci:0.1.0:bafybeicdvt7cbezzptcwpmjfz4pg2nkfa6oez2l6ptqufarsxirrvlonqm
+- balancer/liquidity_provision_abci:0.1.0:bafybeigchesydp5dusscvelsyzrhhd7f72lrfg7iwlqmop6ljnizehfplm
+- balancer/pool_manager_abci:0.1.0:bafybeicrialf4wk4iopqcnm3emdd4yfhw4bmby2jadzlpuo2cytkhwyhyu
+- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/registration_abci:0.1.0:bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a
+- valory/reset_pause_abci:0.1.0:bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu
+- valory/termination_abci:0.1.0:bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe
+- valory/transaction_settlement_abci:0.1.0:bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4
 behaviours:
   main:
     args: {}
@@ -204,5 +204,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-cli-ipfs:
-    version: ==1.48.0
+    version: ==1.50.0
 is_abstract: false

--- a/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
+++ b/packages/balancer/skills/fear_and_greed_oracle_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
+- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/liquidity_provision_abci/skill.yaml
+++ b/packages/balancer/skills/liquidity_provision_abci/skill.yaml
@@ -24,14 +24,14 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
+- balancer/managed_pool:0.1.0:bafybeifpwwu3frha2k2mticchc4qxnaceaswuamqfq2ejb6m5e6iwcuo3q
+- valory/gnosis_safe:0.1.0:bafybeiafp7bu2ah3zypqyvpzkdvnwbjkr5cqt53zp3vrk6jqlcpntxqdia
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/transaction_settlement_abci:0.1.0:bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4
 behaviours:
   main:
     args: {}

--- a/packages/balancer/skills/pool_manager_abci/skill.yaml
+++ b/packages/balancer/skills/pool_manager_abci/skill.yaml
@@ -24,13 +24,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- balancer/managed_pool:0.1.0:bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
+- balancer/managed_pool:0.1.0:bafybeifpwwu3frha2k2mticchc4qxnaceaswuamqfq2ejb6m5e6iwcuo3q
+- valory/gnosis_safe:0.1.0:bafybeiafp7bu2ah3zypqyvpzkdvnwbjkr5cqt53zp3vrk6jqlcpntxqdia
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/transaction_settlement_abci:0.1.0:bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4
 behaviours:
   main:
     args: {}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,14 +1,14 @@
 {
     "dev": {
-        "contract/balancer/managed_pool/0.1.0": "bafybeifkc56usi3dvouduitif6e3mge5ji7umvk3hw4i7qutagihjpvw6m",
-        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeidxvsswhu6rqr6ijoaehtqjmdbubmt7lloe6ecbehho46dwnx76nu",
-        "skill/balancer/pool_manager_abci/0.1.0": "bafybeigosmk5tcl6s5oyzqd2bhxcjlggiqsapwwb5tdkeahzstkrmcuigm",
-        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeiggrik46ypxiepot4tafch3ujsnkawacvmm2pjauoq7p75jsw4puq",
-        "skill/balancer/liquidity_provision_abci/0.1.0": "bafybeicki5skefycmvzjy2l2aggcti3x2y2stev7k6avyf2gra7fb4buyu",
-        "agent/balancer/autonomous_fund/0.1.0": "bafybeigirzsyw7m47icyl4jd6oxid6xm5rkea3eena6vqxdlji4i47zv4a",
-        "service/balancer/autonomous_fund_gnosis/0.1.0": "bafybeigvb4c65r2imymulqnrif2niv7xlldxv72dyru62lgwcbzyf2vzvu",
-        "service/balancer/autonomous_fund_goerli/0.1.0": "bafybeicauzskauyp2st557z4atidp7ctaant3wsc2kfsih3mmdllbedv74",
-        "service/balancer/autonomous_fund/0.1.0": "bafybeieina6fyq7762otrkriebwlhtmufkxkd42uzs7reqxgfl6o2pejgy"
+        "contract/balancer/managed_pool/0.1.0": "bafybeifpwwu3frha2k2mticchc4qxnaceaswuamqfq2ejb6m5e6iwcuo3q",
+        "skill/balancer/autonomous_fund_abci/0.1.0": "bafybeiahetwxxfo2h55hskgvccz624i6w5wq6vs5ber4osngzorfpxxtea",
+        "skill/balancer/pool_manager_abci/0.1.0": "bafybeicrialf4wk4iopqcnm3emdd4yfhw4bmby2jadzlpuo2cytkhwyhyu",
+        "skill/balancer/fear_and_greed_oracle_abci/0.1.0": "bafybeicdvt7cbezzptcwpmjfz4pg2nkfa6oez2l6ptqufarsxirrvlonqm",
+        "skill/balancer/liquidity_provision_abci/0.1.0": "bafybeigchesydp5dusscvelsyzrhhd7f72lrfg7iwlqmop6ljnizehfplm",
+        "agent/balancer/autonomous_fund/0.1.0": "bafybeifod3vme4xrwoniptkuks2hazpta6iuluynkgwwvvoal2hqj32sp4",
+        "service/balancer/autonomous_fund_gnosis/0.1.0": "bafybeidqgt75fwe7ntmbcs2pmcpj6wmjhtbma4kgnkzo63i2htfq642lcu",
+        "service/balancer/autonomous_fund_goerli/0.1.0": "bafybeibuozg5xa6wzrd5sizon3vaddqyfhalouoezf4z7m3izrjid3wb4y",
+        "service/balancer/autonomous_fund/0.1.0": "bafybeiesv363c6qmuhidrbubmv2dyxijtytpgdfyplysntvbwy7mxaw3ja"
     },
     "third_party": {
         "protocol/valory/abci/0.1.0": "bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u",
@@ -19,21 +19,21 @@
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeie6ynnoavvk2fpbn426nlp32sxrj7pz5esgebtlezy4tmx5gjretm",
-        "contract/valory/service_registry/0.1.0": "bafybeiby5x4wfdywlenmoudbykdxohpq2nifqxfep5niqgxrjyrekyahzy",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeig3vqcoxgp56uis3npzgbpfsgu4ku2t74ks6qsabzutacrmbziee4",
+        "contract/valory/service_registry/0.1.0": "bafybeidrbrx5np67xc2rm5jvugplopeobawwqongp6meahhzzpzqsgolsu",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeiafp7bu2ah3zypqyvpzkdvnwbjkr5cqt53zp3vrk6jqlcpntxqdia",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "connection/valory/abci/0.1.0": "bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq",
+        "connection/valory/abci/0.1.0": "bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra",
         "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
         "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "connection/valory/ipfs/0.1.0": "bafybeiflaxrnepfn4hcnq5pieuc7ki7d422y3iqb54lv4tpgs7oywnuhhq",
+        "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe",
-        "skill/valory/registration_abci/0.1.0": "bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea",
-        "skill/valory/termination_abci/0.1.0": "bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay"
+        "skill/valory/abstract_abci/0.1.0": "bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihbor7t3ozvzxqbiie5wl57ol3k7sqkhd22q2boogmwzj7sfvzic4",
+        "skill/valory/registration_abci/0.1.0": "bafybeierykfwmk3gyv4b6szl3xbnngzztsruh6d6k6rcom32fnuveplm5a",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeihcm6h4ae4lwjwu5k3prdyj7mvxv2plzpl444vmjzwhwwp5qathbu",
+        "skill/valory/termination_abci/0.1.0": "bafybeif2gi2zvnixowmrqgvu6jm3eytwik7nvngv7cz5i44etg3iueorfe"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -23,3 +23,4 @@ from setuptools import find_packages, setup  # type: ignore
 
 if __name__ == "__main__":
     setup(packages=[])
+

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,12 @@ deps =
     pytest-cov==4.0.0
     pytest-asyncio==0.20.3
     requests==2.28.1
-    open-aea==1.48.0
-    open-aea-ledger-ethereum==1.48.0
-    open-aea-ledger-cosmos==1.48.0
-    open-aea-cli-ipfs==1.48.0
-    open-aea-test-autonomy==0.14.6
-    open-autonomy==0.14.6
+    open-aea==1.50.0
+    open-aea-ledger-ethereum==1.50.0
+    open-aea-ledger-cosmos==1.50.0
+    open-aea-cli-ipfs==1.50.0
+    open-aea-test-autonomy==0.14.9
+    open-autonomy==0.14.9
     openapi-core==0.15.0
     openapi-spec-validator<0.5.0,>=0.4.0
     protobuf<4.25.0,>=4.21.6


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.50.0
- Bumps open-aea-ledger-ethereum to ==1.50.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.50.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.50.0
- Bumps open-aea-ledger-cosmos to ==1.50.0
- Bumps open-aea-ledger-solana to ==1.50.0
- Bumps open-aea-cli-ipfs to ==1.50.0
- Bumps open-autonomy to ==0.14.9
- Bumps open-aea-test-autonomy to ==0.14.9